### PR TITLE
NEW: Navbar hover + replace support modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,17 @@ popup.HTML:
 ```
 popup.JS:
 ```JS
-    FEATURENAME: false
+const featureIds = [
+    FEATURENAME: false // add this line to the end
+   ];
 ```
+```JS
+document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.sync.get({
+    enabled: true,
+    FEATURENAME: false, // add this line to the end
+```
+
 Manifest.json:
 ```json
     {
@@ -101,6 +110,7 @@ chrome.storage.sync.get({ FEATURENAME: false, enabled: true }, (data) => {
 ```
 [Better-Falix] FEATURENAME: logged message here
 ```
+
    A basic feature logs the following events:
    - Script loading (at the start of the file)
    - Script Enabled (after the enabled check)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Removes all "How to connect" steps, DNS verification sections, and the "Server N
 Removes the most annoying popup ever (the exit discount modal and its backdrop) from falixnodes.net.
 - **its-just paper:** 
 Renames "Craftbukkit / Spigot / PaperSpigot" to "Paper" in the server type dropdown for clarity.
+- **Navbar Hover**
+Opens and closes the navbar when you hover on/off it.
+- **replace Support Modal**
+Replaces the support modal with a cleaner one and adds a copy all button.
 
 **NAVIGATION**
 - **Server Name Button:** Makes the server name in the navbar (current-server-info) clickable to go to the main page, handy for when using the mobile nav bar.

--- a/features/index.js
+++ b/features/index.js
@@ -1,0 +1,129 @@
+// [better-falix] open navigation hover: Script loading
+console.log('[Better-Falix] open navigation hover: Script loading');
+
+chrome.storage.sync.get({ openNavigationHover: false, enabled: true }, (data) => {
+  if (!data.enabled || !data.openNavigationHover) {
+    console.log('[Better-Falix] open navigation hover: Script disabled');
+    return;
+  }
+  console.log('[Better-Falix] open navigation hover: Script enabled');
+
+  // --------- START FEATURE ----------
+
+  function getSidebar() {
+    return document.getElementById('mainSidebar');
+  }
+
+  // Create a hover zone at the left edge of the screen
+  const hoverZone = document.createElement('div');
+  hoverZone.style.position = 'fixed';
+  hoverZone.style.left = '0';
+  hoverZone.style.top = '0';
+  hoverZone.style.width = '40px';
+  hoverZone.style.height = '100vh';
+  hoverZone.style.zIndex = '9999';
+  hoverZone.style.background = 'transparent';
+  hoverZone.style.pointerEvents = 'auto';
+
+  document.body.appendChild(hoverZone);
+
+  let navOpenedByFeature = false;
+  let closeTimeout = null;
+
+  function isSidebarCollapsed(sidebar) {
+    return sidebar.classList.contains('collapsed');
+  }
+
+  function isSidebarMobileOpen(sidebar) {
+    return sidebar.classList.contains('show');
+  }
+
+  function openSidebar() {
+    const sidebar = getSidebar();
+    if (!sidebar) return;
+    // Desktop: remove 'collapsed'
+    if (window.innerWidth >= 1200) {
+      if (isSidebarCollapsed(sidebar)) {
+        sidebar.classList.remove('collapsed');
+        navOpenedByFeature = true;
+        console.log('[Better-Falix] open navigation hover: Sidebar opened (desktop)');
+      }
+    } else {
+      // Mobile: add 'show'
+      if (!isSidebarMobileOpen(sidebar)) {
+        sidebar.classList.add('show');
+        navOpenedByFeature = true;
+        console.log('[Better-Falix] open navigation hover: Sidebar opened (mobile)');
+      }
+    }
+  }
+
+  function closeSidebar() {
+    const sidebar = getSidebar();
+    if (!sidebar) return;
+    if (!navOpenedByFeature) return;
+    // Desktop: add 'collapsed'
+    if (window.innerWidth >= 1200) {
+      if (!isSidebarCollapsed(sidebar)) {
+        sidebar.classList.add('collapsed');
+        navOpenedByFeature = false;
+        console.log('[Better-Falix] open navigation hover: Sidebar closed (desktop)');
+      }
+    } else {
+      // Mobile: remove 'show'
+      if (isSidebarMobileOpen(sidebar)) {
+        sidebar.classList.remove('show');
+        navOpenedByFeature = false;
+        console.log('[Better-Falix] open navigation hover: Sidebar closed (mobile)');
+      }
+    }
+  }
+
+  hoverZone.addEventListener('mouseenter', () => {
+    openSidebar();
+    if (closeTimeout) clearTimeout(closeTimeout);
+  });
+
+  hoverZone.addEventListener('mouseleave', () => {
+    // Only close if mouse is not over sidebar
+    closeTimeout = setTimeout(() => {
+      const sidebar = getSidebar();
+      if (!sidebar) return;
+      // If mouse is not over sidebar, close
+      if (!sidebar.matches(':hover')) {
+        closeSidebar();
+      }
+    }, 300);
+  });
+
+  function attachSidebarListeners() {
+    const sidebar = getSidebar();
+    if (!sidebar) return;
+    // Remove previous listeners if any (by cloning)
+    const newSidebar = sidebar.cloneNode(true);
+    sidebar.parentNode.replaceChild(newSidebar, sidebar);
+
+    newSidebar.addEventListener('mouseleave', () => {
+      closeTimeout = setTimeout(() => {
+        // If mouse is not over hoverZone, close
+        if (!hoverZone.matches(':hover')) {
+          closeSidebar();
+        }
+      }, 300);
+    });
+    newSidebar.addEventListener('mouseenter', () => {
+      if (closeTimeout) clearTimeout(closeTimeout);
+    });
+  }
+
+  // Attach listeners now and on DOMContentLoaded in case sidebar is loaded later
+  attachSidebarListeners();
+  document.addEventListener('DOMContentLoaded', attachSidebarListeners);
+
+  // Clean up on page unload
+  window.addEventListener('beforeunload', () => {
+    hoverZone.remove();
+  });
+
+  console.log('[Better-Falix] open navigation hover: Script loaded successfully');
+});

--- a/features/navbarhover/index.js
+++ b/features/navbarhover/index.js
@@ -1,12 +1,12 @@
-// [better-falix] open navigation hover: Script loading
-console.log('[Better-Falix] open navigation hover: Script loading');
+// [better-falix] navbarhover: Script loading
+console.log('[Better-Falix] navbarhover: Script loading');
 
-chrome.storage.sync.get({ openNavigationHover: false, enabled: true }, (data) => {
-  if (!data.enabled || !data.openNavigationHover) {
-    console.log('[Better-Falix] open navigation hover: Script disabled');
+chrome.storage.sync.get({ navbarHover: false, enabled: true }, (data) => {
+  if (!data.enabled || !data.navbarHover) {
+    console.log('[Better-Falix] navbarhover: Script disabled');
     return;
   }
-  console.log('[Better-Falix] open navigation hover: Script enabled');
+  console.log('[Better-Falix] navbarhover: Script enabled');
 
   // --------- START FEATURE ----------
 

--- a/features/replace-support-modal/index.js
+++ b/features/replace-support-modal/index.js
@@ -1,0 +1,84 @@
+// [better-falix] replaceSupportModal: Script loading
+console.log('[better-falix] replaceSupportModal: Script loading');
+
+chrome.storage.sync.get({ replaceSupportModal: false, enabled: true }, (data) => {
+  if (!data.enabled || !data.replaceSupportModal) {
+    console.log('[better-falix] replaceSupportModal: Script disabled');
+    return;
+  }
+  console.log('[better-falix] replaceSupportModal: Script enabled');
+
+  //  --------- START FEATURE ----------
+
+  function hideSupportModalBody() {
+    // Replace all modal-body elements that are support modals
+    document.querySelectorAll('.modal-body').forEach((modalBody) => {
+      if (
+        modalBody.querySelector('.support-warning') &&
+        modalBody.querySelector('.support-info-card')
+      ) {
+        // Get values from the original modal if possible
+        const supportId = modalBody.querySelector('.support-info-text')?.textContent?.trim() || '';
+        const supportPin = modalBody.querySelectorAll('.support-info-text')[1]?.textContent?.trim() || '';
+        const serverName = modalBody.querySelector('.support-info-card:last-child .support-info-text')?.textContent?.trim() || '';
+
+        // Add a copy button at the top that copies both values
+        const copyAllBtn = `
+          <button class="btn connect-inline-copy" id="bf-support-copy-all" style="margin-bottom:12px;" title="Copy all">
+            <svg class="svg-inline--fa fa-copy" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="copy" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M208 0L332.1 0c12.7 0 24.9 5.1 33.9 14.1l67.9 67.9c9 9 14.1 21.2 14.1 33.9L448 336c0 26.5-21.5 48-48 48l-192 0c-26.5 0-48-21.5-48-48l0-288c0-26.5 21.5-48 48-48zM48 128l80 0 0 64-64 0 0 256 192 0 0-32 64 0 0 48c0 26.5-21.5 48-48 48L48 512c-26.5 0-48-21.5-48-48L0 176c0-26.5 21.5-48 48-48z"></path></svg>
+            <span>Copy All</span>
+          </button>
+        `;
+
+        const newHtml = `
+      ${copyAllBtn}
+      <div class="connect-steps" id="javaSteps">
+        <div class="connect-bedrock-details">
+          <div class="bedrock-detail-row">
+            <span class="bedrock-label">SUPPORT ID:</span>
+            <span class="bedrock-value">${supportId}</span>
+            <button class="btn connect-inline-copy" onclick="copyConnectionInfo('${supportId}', this)" title="Copy address">
+              <svg class="svg-inline--fa fa-copy" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="copy" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M208 0L332.1 0c12.7 0 24.9 5.1 33.9 14.1l67.9 67.9c9 9 14.1 21.2 14.1 33.9L448 336c0 26.5-21.5 48-48 48l-192 0c-26.5 0-48-21.5-48-48l0-288c0-26.5 21.5-48 48-48zM48 128l80 0 0 64-64 0 0 256 192 0 0-32 64 0 0 48c0 26.5-21.5 48-48 48L48 512c-26.5 0-48-21.5-48-48L0 176c0-26.5 21.5-48 48-48z"></path></svg>
+            </button>
+          </div>
+          <div class="bedrock-detail-row">
+            <span class="bedrock-label">SupportPIN:</span><span class="bedrock-value">${supportPin}</span>
+            <button class="btn connect-inline-copy" onclick="copyConnectionInfo('${supportPin}', this)" title="Copy to clipboard">
+              <svg class="svg-inline--fa fa-copy" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="copy" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M208 0L332.1 0c12.7 0 24.9 5.1 33.9 14.1l67.9 67.9c9 9 14.1 21.2 14.1 33.9L448 336c0 26.5-21.5 48-48 48l-192 0c-26.5 0-48-21.5-48-48l0-288c0-26.5 21.5-48 48-48zM48 128l80 0 0 64-64 0 0 256 192 0 0-32 64 0 0 48c0 26.5-21.5 48-48 48L48 512c-26.5 0-48-21.5-48-48L0 176c0-26.5 21.5-48 48-48z"></path></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+      `;
+        modalBody.innerHTML = newHtml;
+
+        // Add copy event for the "Copy All" button
+        setTimeout(() => {
+          const btn = modalBody.querySelector('#bf-support-copy-all');
+          if (btn) {
+            btn.addEventListener('click', () => {
+              const text = `Support ID: ${supportId}\nSupport PIN: ${supportPin}`;
+              navigator.clipboard.writeText(text);
+            });
+          }
+        }, 0);
+      }
+    });
+  }
+
+  function observeModals() {
+    hideSupportModalBody();
+    const observer = new MutationObserver(hideSupportModalBody);
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observeModals);
+  } else {
+    observeModals();
+  }
+
+  setTimeout(() => {
+    console.log('[better-falix] replaceSupportModal: Script loaded sucsessfully');
+  }, 10);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -93,10 +93,15 @@
       "matches": ["https://client.falixnodes.net/*"],
       "js": ["features/server-name-button/index.js"],
       "run_at": "document_idle"
-    },
+    }, 
     {
       "matches": ["https://client.falixnodes.net/*"],
       "js": ["features/navbarhover/index.js"],
+      "run_at": "document_idle"
+    },  
+    {
+      "matches": ["https://client.falixnodes.net/*"],
+      "js": ["features/replace-support-modal/index.js"],
       "run_at": "document_idle"
     }
   ]

--- a/manifest.json
+++ b/manifest.json
@@ -93,6 +93,11 @@
       "matches": ["https://client.falixnodes.net/*"],
       "js": ["features/server-name-button/index.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://client.falixnodes.net/*"],
+      "js": ["features/navbarhover/index.js"],
+      "run_at": "document_idle"
     }
   ]
 }

--- a/popup.html
+++ b/popup.html
@@ -180,7 +180,7 @@
         <button class="feature-btn" id="navbarHover" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
       </div>   
       <div class="feature-row">
-        <span class="feature-label" data-tooltip="Replaces the support modal with a cleaner one and adds a copy all button">replace Support Modal</span>
+        <span class="feature-label" data-tooltip="Replaces the support modal with a cleaner one and adds a copy all button.">replace Support Modal</span>
         <button class="feature-btn" id="replaceSupportModal" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
       </div>   
     </div>

--- a/popup.html
+++ b/popup.html
@@ -178,7 +178,11 @@
       <div class="feature-row">
         <span class="feature-label" data-tooltip="Opens and closes the navbar when you hover on/off it.">Navbar Hover</span>
         <button class="feature-btn" id="navbarHover" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
-      </div>    
+      </div>   
+      <div class="feature-row">
+        <span class="feature-label" data-tooltip="Replaces the support modal with a cleaner one and adds a copy all button">replace Support Modal</span>
+        <button class="feature-btn" id="replaceSupportModal" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
+      </div>   
     </div>
 
     <!-- Navigation Features -->

--- a/popup.html
+++ b/popup.html
@@ -168,13 +168,17 @@
         <button class="feature-btn" id="removeHowToConnect" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
       </div>
       <div class="feature-row">
-        <span class="feature-label" data-tooltip="Removes the most annoying popup ever (the exit discount modal and its backdrop) from falixnodes.net.">Remove-exit-discount</span>
+        <span class="feature-label" data-tooltip="Removes the most annoying popup ever (the exit discount modal and its backdrop) from falixnodes.net.">Remove Exit-Discount</span>
         <button class="feature-btn" id="removeExitDiscount" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
       </div>
       <div class="feature-row">
         <span class="feature-label" data-tooltip="Renames 'Craftbukkit / Spigot / PaperSpigot' to 'Paper' in the server type dropdown for clarity.">it's just paper</span>
         <button class="feature-btn" id="itsjustPaper" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
-      </div>
+      </div>    
+      <div class="feature-row">
+        <span class="feature-label" data-tooltip="Opens and closes the navbar when you hover on/off it.">Navbar Hover</span>
+        <button class="feature-btn" id="navbarHover" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
+      </div>    
     </div>
 
     <!-- Navigation Features -->

--- a/popup.js
+++ b/popup.js
@@ -65,7 +65,9 @@ document.addEventListener('DOMContentLoaded', () => {
     removeHowToConnect: false,
     removeExitDiscount: false,
     itsjustPaper: false,
-    serverNameButton: false
+    serverNameButton: false,
+    navbarHover: false,
+    replaceSupportModal: false,
   }, (data) => {
     updateToggleBtn(data.enabled);
     updateFeatureButtons(data);

--- a/popup.js
+++ b/popup.js
@@ -18,7 +18,8 @@ const featureIds = [
   'removeHowToConnect',
   'removeExitDiscount',
   'itsjustPaper',
-  'serverNameButton'
+  'serverNameButton',
+  'navbarHover'
 ];
 
 function setFeatureBtnState(btn, enabled) {

--- a/popup.js
+++ b/popup.js
@@ -19,7 +19,8 @@ const featureIds = [
   'removeExitDiscount',
   'itsjustPaper',
   'serverNameButton',
-  'navbarHover'
+  'navbarHover',
+  'replaceSupportModal'
 ];
 
 function setFeatureBtnState(btn, enabled) {


### PR DESCRIPTION
NEW: Navbar hover (makes the navbar open/close when you hover at the side)
NEW: Replace Support modal (makes the support modal empty and use the connection table for the info, also adds a copy all button)
README: Added the initial load to development guide (popup.js)