### PR TITLE
NEW: upload-create-hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Opens and closes the navbar when you hover on/off it.
 Replaces the support modal with a cleaner one and adds a copy all button.
 - **Server Name Button**
 Makes the server name in the navbar clickable and redirect you to the main page.
-
+- **upload-create-hover:**  
+Makes the Upload and Create buttons show their dropdowns when hovered.
 
 **NAVIGATION**
 - **Server Name Button:** Makes the server name in the navbar (current-server-info) clickable to go to the main page, handy for when using the mobile nav bar.

--- a/features/upload-create-hover/index.js
+++ b/features/upload-create-hover/index.js
@@ -1,0 +1,64 @@
+// [better-falix] upload-create-hover: Script loading
+console.log('[better-falix] upload-create-hover: Script loading');
+
+chrome.storage.sync.get({ uploadCreateHover: false, enabled: true }, (data) => {
+  if (!data.enabled || !data.uploadCreateHover) {
+    console.log('[better-falix] upload-create-hover: Script disabled');
+    return;
+  }
+  console.log('[better-falix] upload-create-hover: Script enabled');
+
+  //  --------- START FEATURE ----------
+  
+  function addHoverDropdown(id) {
+    const btn = document.getElementById(id);
+    if (!btn) return;
+    const dropdown = btn.nextElementSibling;
+    if (!dropdown || !dropdown.classList.contains('dropdown-menu')) return;
+
+    let openTimeout = null;
+
+    btn.addEventListener('mouseenter', () => {
+      openTimeout = setTimeout(() => {
+        btn.classList.add('show');
+        dropdown.classList.add('show');
+        dropdown.style.display = 'block';
+      }, 300); // 0.5 seconds delay
+    });
+    btn.addEventListener('mouseleave', () => {
+      clearTimeout(openTimeout);
+      setTimeout(() => {
+        if (!dropdown.matches(':hover')) {
+          btn.classList.remove('show');
+          dropdown.classList.remove('show');
+          dropdown.style.display = '';
+        }
+      }, 100);
+    });
+    dropdown.addEventListener('mouseleave', () => {
+      btn.classList.remove('show');
+      dropdown.classList.remove('show');
+      dropdown.style.display = '';
+    });
+    dropdown.addEventListener('mouseenter', () => {
+      btn.classList.add('show');
+      dropdown.classList.add('show');
+      dropdown.style.display = 'block';
+    });
+  }
+
+  function setup() {
+    addHoverDropdown('createDropdown');
+    addHoverDropdown('uploadDropdown');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup);
+  } else {
+    setup();
+  }
+
+  setTimeout(() => {
+    console.log('[better-falix] upload-create-hover: Script loaded sucsessfully');
+  }, 10);
+});

--- a/manifest.json
+++ b/manifest.json
@@ -118,6 +118,11 @@
       "matches": ["https://client.falixnodes.net/*"],
       "js": ["features/fix-checkbox-icon/index.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://client.falixnodes.net/*"],
+      "js": ["features/upload-create-hover/index.js"],
+      "run_at": "document_idle"
     }
   ]
 }

--- a/popup.html
+++ b/popup.html
@@ -424,6 +424,10 @@
             <span class="feature-label" data-tooltip="Remove 'Console' and 'Files' categories (keep items).">Remove "Console" and "Files" categories</span>
             <button class="feature-btn" id="removeConsoleFilesCategory" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
           </div>
+          <div class="feature-row">
+            <span class="feature-label" data-tooltip="Makes the Upload and Create buttons show their dropdowns when hovered.">Upload/Create Hover</span>
+            <button class="feature-btn" id="uploadCreateHover" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
+         </div>
         </div>
       
        <div class="category">Bug Fixes</div>

--- a/popup.js
+++ b/popup.js
@@ -21,7 +21,8 @@ const featureIds = [
   'serverNameButton',
   'navbarHover',
   'replaceSupportModal',
-  'fixcheckboxicon'
+  'fixcheckboxicon',
+  'uploadCreateHover'
 ];
 
 function setFeatureBtnState(btn, enabled) {
@@ -103,7 +104,8 @@ document.addEventListener('DOMContentLoaded', () => {
     serverNameButton: false,
     navbarHover: false,
     replaceSupportModal: false,
-    fixcheckboxicon: false
+    fixcheckboxicon: false,
+    uploadCreateHover: false,
   }, (data) => {
     updateToggleBtn(data.enabled);
     updateFeatureButtons(data);


### PR DESCRIPTION
Add: upload-create-hover
  Makes the upload and create buttons in the file manager open when you hover above them
  It currently has a 0.5 second delay beacuse the create dropdown popup would display above the upload one