### PR TITLE
Extra elements for themes (disk usage analyse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Optionally remove support-related links from the navbar.
 
 **BUG FIXES**
 - **Fix cursed checkbox icon**
-Fixes the filemanager file selection checkbox being cursed (go look at it).
+Fixes the filemanager file selection checkbox being cursed (issue should already be fixed, kept for legacy purposes).
 
 
 ## Usage

--- a/popup.html
+++ b/popup.html
@@ -433,7 +433,7 @@
        <div class="category">Bug Fixes</div>
         <div class="feature-list">
           <div class="feature-row">
-            <span class="feature-label" data-tooltip="Fixes the filemanager file selection checkbox being cursed. (go look at it).">Fix cursed checkbox icon</span>
+            <span class="feature-label" data-tooltip="Fixes the filemanager file selection checkbox being cursed. (Should be fixed, will be removed soon).">FIXED BY FALIX: cursed checkbox icon</span>
             <button class="feature-btn" id="fixcheckboxicon" aria-pressed="false" tabindex="0"><span class="dot"></span></button>
           </div>
       </div>

--- a/themes/light-mode/index.js
+++ b/themes/light-mode/index.js
@@ -384,6 +384,28 @@
             el.style.color = '#000';
         });
 
+        // Set chart container background to rgb(150,150,150)
+        if (!document.getElementById('light-mode-chart-container-style')) {
+          var chartContainerStyle = document.createElement('style');
+          chartContainerStyle.id = 'light-mode-chart-container-style';
+          chartContainerStyle.textContent = `
+/* Try common chart container classes and direct parent of canvas */
+.chart-container,
+#diskUsageChart,
+#diskUsageChart:parent,
+#diskUsageChart:not(canvas) {
+  background-color: rgb(150,150,150) !important;
+}
+#diskUsageChart {
+  background-color: transparent !important;
+}
+#diskUsageChart:parent {
+  background-color: rgb(150,150,150) !important;
+}
+`;
+          document.head.appendChild(chartContainerStyle);
+        }
+
         // Force background-color: white !important for modal-body, modal-header bg-1000 border-700, card-body
         // and make all text and headers inside black
         if (!document.getElementById('light-mode-modal-card-style')) {

--- a/themes/light-mode/index.js
+++ b/themes/light-mode/index.js
@@ -406,6 +406,18 @@
           document.head.appendChild(chartContainerStyle);
         }
 
+        // Make label.btn.btn-outline-secondary[for="recursiveMode"] text black
+        if (!document.getElementById('light-mode-outline-secondary-label-style')) {
+          var outlineSecondaryLabelStyle = document.createElement('style');
+          outlineSecondaryLabelStyle.id = 'light-mode-outline-secondary-label-style';
+          outlineSecondaryLabelStyle.textContent = `
+label.btn.btn-outline-secondary[for="recursiveMode"] {
+  color: #000 !important;
+}
+`;
+          document.head.appendChild(outlineSecondaryLabelStyle);
+        }
+
         // Force background-color: white !important for modal-body, modal-header bg-1000 border-700, card-body
         // and make all text and headers inside black
         if (!document.getElementById('light-mode-modal-card-style')) {

--- a/themes/light-mode/index.js
+++ b/themes/light-mode/index.js
@@ -384,6 +384,29 @@
             el.style.color = '#000';
         });
 
+        // Force background-color: white !important for modal-body, modal-header bg-1000 border-700, card-body
+        // and make all text and headers inside black
+        if (!document.getElementById('light-mode-modal-card-style')) {
+          var style = document.createElement('style');
+          style.id = 'light-mode-modal-card-style';
+          style.textContent = `
+.modal-body,
+.modal-header.bg-1000.border-700,
+.card-body {
+  background-color: #fff !important;
+}
+.modal-body,
+.modal-header.bg-1000.border-700,
+.card-body,
+.modal-body *:not(.btn),
+.modal-header.bg-1000.border-700 *:not(.btn),
+.card-body *:not(.btn) {
+  color: #000 !important;
+}
+`;
+          document.head.appendChild(style);
+        }
+
       });
     } else {
       console.error('[better-falix] LIGHT MODE THEME: chrome.storage.sync.get is not available or not running as a Chrome extension content script');

--- a/themes/purple-mode/index.js
+++ b/themes/purple-mode/index.js
@@ -363,6 +363,35 @@ li.breadcrumb-item.active {
 `;
         document.head.appendChild(breadcrumbStyle);
       }
+
+      // Make "Analyze" button (btn-outline-primary with fileManager.analyzeDiskUsage) light purple
+      if (!document.getElementById('purple-mode-analyze-btn-style')) {
+        var analyzeBtnStyle = document.createElement('style');
+        analyzeBtnStyle.id = 'purple-mode-analyze-btn-style';
+        analyzeBtnStyle.textContent = `
+button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"] {
+  color: #a259e6 !important;
+  border-color: #d8b4fe !important;
+  background-color: #faf5ff !important;
+}
+button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:hover,
+button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:focus {
+  color: #fff !important;
+  background-color: #a259e6 !important;
+  border-color: #a259e6 !important;
+}
+button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"] svg {
+  color: #a259e6 !important;
+  fill: #a259e6 !important;
+}
+button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:hover svg,
+button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:focus svg {
+  color: #fff !important;
+  fill: #fff !important;
+}
+`;
+        document.head.appendChild(analyzeBtnStyle);
+      }
     });
   } else {
     console.error('[better-falix] PURPLE MODE THEME: chrome.storage.sync.get is not available or not running as a Chrome extension content script');

--- a/themes/purple-mode/index.js
+++ b/themes/purple-mode/index.js
@@ -372,7 +372,7 @@ li.breadcrumb-item.active {
 button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"] {
   color: #a259e6 !important;
   border-color: #d8b4fe !important;
-  background-color: #faf5ff !important;
+  background-color: #d8b4fe !important;
 }
 button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:hover,
 button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:focus {
@@ -391,6 +391,64 @@ button.btn.btn-outline-primary[onclick="fileManager.analyzeDiskUsage()"]:focus s
 }
 `;
         document.head.appendChild(analyzeBtnStyle);
+      }
+
+      // Make text inside .btn.btn-outline-secondary black
+      if (!document.getElementById('purple-mode-outline-secondary-style')) {
+        var outlineSecondaryStyle = document.createElement('style');
+        outlineSecondaryStyle.id = 'purple-mode-outline-secondary-style';
+        outlineSecondaryStyle.textContent = `
+.btn.btn-outline-secondary,
+.btn.btn-outline-secondary * {
+  color: #111 !important;
+}
+`;
+        document.head.appendChild(outlineSecondaryStyle);
+      }
+
+      // Make Chart.js legend text black for diskUsageChart and all charts
+      if (!document.getElementById('purple-mode-chart-legend-style')) {
+        var chartLegendStyle = document.createElement('style');
+        chartLegendStyle.id = 'purple-mode-chart-legend-style';
+        chartLegendStyle.textContent = `
+#diskUsageChart + div .legend,
+#diskUsageChart + .chartjs-size-monitor + div .legend,
+.chartjs-render-monitor ~ .chartjs-legend,
+.chartjs-legend,
+.chartjs-legend li,
+.chartjs-legend span,
+.chartjs-legend * {
+  color: #111 !important;
+  fill: #111 !important;
+}
+`;
+        document.head.appendChild(chartLegendStyle);
+      }
+
+      // Try to patch Chart.js legend label color via options (for dynamic charts)
+      function patchChartLegendColors() {
+        if (window.Chart && typeof window.Chart === 'function' && window.Chart.instances) {
+          let charts = [];
+          if (typeof window.Chart.instances.forEach === 'function') {
+            window.Chart.instances.forEach(chart => charts.push(chart));
+          } else {
+            charts = Object.values(window.Chart.instances);
+          }
+          charts.forEach(chart => {
+            if (chart.options && chart.options.plugins && chart.options.plugins.legend) {
+              if (!chart.options.plugins.legend.labels) chart.options.plugins.legend.labels = {};
+              chart.options.plugins.legend.labels.color = '#111';
+              if (typeof chart.update === 'function') chart.update();
+            }
+          });
+        }
+      }
+      patchChartLegendColors();
+
+      // Also observe DOM for new charts and patch legend color
+      if (!window.__purpleLegendObserver) {
+        window.__purpleLegendObserver = new MutationObserver(patchChartLegendColors);
+        window.__purpleLegendObserver.observe(document.body, { childList: true, subtree: true });
       }
     });
   } else {


### PR DESCRIPTION
adds a few more elements to both purple theme and light-mode

Known issues: 
- chart.js graphs don't change color for purple mode
- Disk usage chart legend is unreadable beacuse of white text on white background in light-mode